### PR TITLE
Add `repr` and `progress` packages

### DIFF
--- a/PACKAGES
+++ b/PACKAGES
@@ -153,6 +153,7 @@ prometheus
 ptime
 randomconv
 re
+repr
 rfc1951
 rresult
 scrypt-kdf

--- a/PACKAGES
+++ b/PACKAGES
@@ -146,6 +146,7 @@ pbkdf
 pcap-format
 pecu
 ppx_expect
+progress
 prometheus
 #protocol-9p
 #protocol-9p-unix - irmin cconflict


### PR DESCRIPTION
Adds newly-released packages in the Irmin.2.3.0 dependency tree:

 - [`mirage/repr`](https://github.com/mirage/repr/)
 - [`CraigFe/progress`](https://github.com/CraigFe/progress/)